### PR TITLE
Change the matchers for wildcards

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -42,11 +42,14 @@ type (
 		Timeout        string             `toml:"timeout"`
 	}
 	Redis struct {
-		Host    string    `toml:"host"`
-		Port    string    `toml:"port"`
+		Host     string    `toml:"host"`
+		Port     string    `toml:"port"`
+		Password string    `toml:"password"`
 	}
 	Session struct {
 		Timeout    string    `toml:"timeout"`
+		Path       string    `toml:"path"`
+		HttpOnly   bool      `toml:"http_only"`
 	}
 	serverSettings struct {
 		TemplatePath    string        `toml:"template_path"`

--- a/configs/configuration/dev.toml
+++ b/configs/configuration/dev.toml
@@ -1,15 +1,18 @@
 [database]
-  host     = "localhost"
-  port     = "3306"
-  name     = "suglider"
-  user     = ""
-  password = ""
-  timeout  = "5s" # Value can be 1h, 1m, 10s, 2days would be 48h.
+  host      = "localhost"
+  port      = "3306"
+  name      = "suglider"
+  user      = ""
+  password  = ""
+  timeout   = "5s" # Value can be 1h, 1m, 10s, 2days would be 48h.
 [redis]
-  host     = "localhost"
-  port     = "6379"
+  host      = "localhost"
+  port      = "6379"
+  password  = ""
 [session]
-  timeout  = "2h" # Value can be 1h, 1m, 10s, 2days would be 48h.
+  timeout   = "2h" # Value can be 1h, 1m, 10s, 2days would be 48h.
+  path      = "/"
+  http_only = true
 [server]
   graceful_timeout  = 5
   read_timeout      = 5
@@ -17,7 +20,7 @@
   max_header_bytes  = 2
   casbin_config     = "/usr/local/app/configs/rbac_model.conf"
   casbin_table      = "casbin_policies"
-  casbin_cache      = true
+  casbin_cache      = false
   enable_rbac       = true
   template_path     = "/usr/local/app/web/template"
   static_path       = "/usr/local/app/web/static"

--- a/configs/rbac_model.conf
+++ b/configs/rbac_model.conf
@@ -11,4 +11,4 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -14,7 +14,7 @@ var ctx = context.Background()
 func init() {
 	rdb = redis.NewClient(&redis.Options{
 		Addr:     configs.ApplicationConfig.Redis.Host + ":" + configs.ApplicationConfig.Redis.Port,
-		Password: "", // no password set
+		Password: configs.ApplicationConfig.Redis.Password,
 		DB:       0,  // use default DB
 	})
 

--- a/main.go
+++ b/main.go
@@ -72,18 +72,20 @@ func init() {
 
 func main() {
 	apiServer := &authApiSettings {
-		Name:           ServiceName,
-		Version:        Version,
-		TemplatePath:   configs.ApplicationConfig.Server.TemplatePath,
-		StaticPath:     configs.ApplicationConfig.Server.StaticPath,
-		CasbinConfig:   configs.ApplicationConfig.Server.CasbinConfig,
-		CasbinTable:    configs.ApplicationConfig.Server.CasbinTable,
-		CasbinCache:    configs.ApplicationConfig.Server.CasbinCache,
-		ReadTimeout:    configs.ApplicationConfig.Server.ReadTimeout,
-		WriteTimeout:   configs.ApplicationConfig.Server.WriteTimeout,
-		MaxHeaderBytes: configs.ApplicationConfig.Server.MaxHeaderBytes,
-		EnableRbac:     configs.ApplicationConfig.Server.EnableRbac,
-		EnablePprof:    configs.Args.Debug,
+		Name:             ServiceName,
+		Version:          Version,
+		TemplatePath:     configs.ApplicationConfig.Server.TemplatePath,
+		StaticPath:       configs.ApplicationConfig.Server.StaticPath,
+		SessionsPath:     configs.ApplicationConfig.Session.Path,
+		SessionsHttpOnly: configs.ApplicationConfig.Session.HttpOnly,
+		CasbinConfig:     configs.ApplicationConfig.Server.CasbinConfig,
+		CasbinTable:      configs.ApplicationConfig.Server.CasbinTable,
+		CasbinCache:      configs.ApplicationConfig.Server.CasbinCache,
+		ReadTimeout:      configs.ApplicationConfig.Server.ReadTimeout,
+		WriteTimeout:     configs.ApplicationConfig.Server.WriteTimeout,
+		MaxHeaderBytes:   configs.ApplicationConfig.Server.MaxHeaderBytes,
+		EnableRbac:       configs.ApplicationConfig.Server.EnableRbac,
+		EnablePprof:      configs.Args.Debug,
 	}
 
 	if configs.Args.Subpath != "" {

--- a/pkg/api-server/routers.go
+++ b/pkg/api-server/routers.go
@@ -24,20 +24,22 @@ import (
 )
 
 type AuthApiSettings struct {
-	Name            string
-	Version         string
-	SubpathPrefix   string
-	TemplatePath    string
-	StaticPath      string
-	CasbinConfig    string
-	CasbinTable     string
-	GracefulTimeout int
-	ReadTimeout     int
-	WriteTimeout    int
-	MaxHeaderBytes  int
-	EnablePprof     bool
-	EnableRbac      bool
-	CasbinCache     bool
+	Name             string
+	Version          string
+	SubpathPrefix    string
+	TemplatePath     string
+	StaticPath       string
+	SessionsPath     string
+	CasbinConfig     string
+	CasbinTable      string
+	GracefulTimeout  int
+	ReadTimeout      int
+	WriteTimeout     int
+	MaxHeaderBytes   int
+	EnablePprof      bool
+	EnableRbac       bool
+	CasbinCache      bool
+	SessionsHttpOnly bool
 }
 
 type CasbinEnforcerConfig = rbac.CasbinEnforcerConfig
@@ -53,7 +55,8 @@ func (aa * AuthApiSettings) SetupRouter(swag gin.HandlerFunc) *gin.Engine {
 	// time_convert.CookieMaxAge is a global variable from time_convert.go
 	cookieStore.Options(sessions.Options{
 		MaxAge:   time_convert.CookieMaxAge,  // unit second
-		HttpOnly: true,
+		HttpOnly: aa.SessionsHttpOnly,
+		Path:     aa.SessionsPath,
 	})
 
 	if aa.EnablePprof {


### PR DESCRIPTION
The changes from this commit:
- Wildcards matchers for casbin object and action
- Add the redis password in the config
- Add session's path and http_only option in the config